### PR TITLE
fix initialization order

### DIFF
--- a/opm/autodiff/AquiferInterface.hpp
+++ b/opm/autodiff/AquiferInterface.hpp
@@ -67,9 +67,9 @@ namespace Opm
     AquiferInterface( const Aquancon::AquanconOutput& connection,
                       const std::unordered_map<int, int>& cartesian_to_compressed,
                       const Simulator& ebosSimulator)
-                    : ebos_simulator_(ebosSimulator)
+                    : connection_(connection)
+                    , ebos_simulator_(ebosSimulator)
                     , cartesian_to_compressed_(cartesian_to_compressed)
-                    , connection_(connection)
     {}
 
     // Deconstructor


### PR DESCRIPTION
this fixes the actual error.

see, in the class you have declaration as
```c++
...
protected:
    const Aquancon::AquanconOutput connection_;
    const Simulator& ebos_simulator_;
    const std::unordered_map<int, int> cartesian_to_compressed_;
```
so we need to keep the same order in the *initializer list*  - the stuff after the :. constructor parameter orders is not the issue.